### PR TITLE
some best practices + personal preferences

### DIFF
--- a/dn.sh
+++ b/dn.sh
@@ -1,29 +1,28 @@
-function spl() {
-    # usage split "string" "delim" N
-    # returns the Nth element from the split array
-    # https://github.com/dylanaraps/pure-bash-bible#split-a-string-on-a-delimiter
-    IFS=$'\n' read -d "" -ra arr <<< "${1//$2/$'\n'}"
-    printf '%s ' "${arr[@]}"
-}
-function dnsh() { 
-    : ${DEBUG:=0}
+#!/usr/bin/env bash
 
-    q=$1
-    srv=$2
-    tid="\x13\x37"
-    flags="\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00" # standard, recursive, 1-question query
-    qstr=""
-    qtyp="\x00\x01\x00\x01" # type (A) class (IN)
-    for s in $(spl $q "."); do
-        qstr=$qstr$(printf '\\x%02X' "${#s}")$s
+function dnsh() { 
+    : "${DEBUG:=0}"
+
+    q="${1}"
+    srv="${2}"
+    tid='\x13\x37'
+    flags='\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00' # standard, recursive, 1-question query
+    qstr=''
+    qtyp='\x00\x01\x00\x01"' # type (A) class (IN)
+    
+    # splits up query by .
+    mapfile -t spl_arr <<< "${q//./$'\n'}"
+    
+    for s in "${spl_arr[@]}" ; do
+        qstr+="$(printf '\\x%02X' "${#s}")${s}"
     done
-    qstr=$qstr"\x00"
-    q="$tid$flags$qstr$qtyp"
-    exec 5<>/dev/udp/$srv/53
-    echo -n -e "$q" >&5 
+    qstr+='\x00'
+    q="${tid}${flags}${qstr}${qtyp}"
+    exec 5<>/dev/udp/"${srv}"/53
+    echo -n -e "${q}" >&5 
     cat <&5 | hexdump -C
 }
-dnsh $1 $2
+dnsh "${1}" "${2}"
 # pure bash b64
 # https://gist.github.com/p120ph37/015941a57f0d8f9a1722
 


### PR DESCRIPTION
here are the changes that I added:

1. added a shebang, I prefer the `#!/usr/bin/env bash` compared to the normal `#!/bin/bash`, so that way if your environment specifies a different location for bash it will use whatever is first ( this is necessary for FreeBSD systems, since they install bash into `/usr/local/bin/bash` (IIRC).
2. Replaced the [spl function](https://github.com/dylanaraps/pure-bash-bible/tree/8c19d0b482b04d8d50fb72b4c5148b41ce605c6d#split-a-string-on-a-delimiter) with just a mapfile, because mapfile will create an array for you based on newline delimited input ( which is happening with the variable substitution ( i.e. `${1//$2/$'\n'}"` ) ).
3. Instead of doing `qstr="${qstr}..."` a bunch of times to append to a string you can just use `+=` for the variable, so that is used instead of appending the alternative way.
4. replaced `"` with `'` where variable substitution isn't necessary ( just for best practices sake )
5. Followed [shellcheck](https://github.com/koalaman/shellcheck)'s recommendations for styling things ( `shellcheck -S style -o all <script>.sh` )
   - double quoted all variables
   - used parenthesis for all variables ( i.e. `"${var}"` ) 

I'll indicate which changes for what by putting a comment with a number in it, which will correspond to the numbers above.

Might want to also consider adding at least this: https://elrey.casa/bash/scripting/harden

Normally I always format my [scripts](https://github.com/elreydetoda/all-linux-tings/tree/master/scripts) to use this as well: https://elrey.casa/bash/scripting/main